### PR TITLE
Support function base name and alias in `udf` macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "default-args"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b278f5a88847c427cdc4c3408916fb2135f179444e095cd207294d4c28c5e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,6 +68,43 @@ dependencies = [
 
 [[package]]
 name = "gandiva_rust_udf_common"
+version = "0.1.0"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "indexmap"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "gandiva_rust_udf_shared"
+version = "0.1.0"
+dependencies = [
+ "gandiva_rust_udf_type",
+ "lazy_static",
+ "libc",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "strfmt",
+ "syn",
+ "toml",
+ "walkdir",
+]
+
+[[package]]
+name = "gandiva_rust_udf_type"
 version = "0.1.0"
 
 [[package]]
@@ -149,7 +197,7 @@ checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strfmt",
- "syn",
+ "syn 2.0.52",
  "toml",
  "walkdir",
 ]
@@ -42,11 +42,12 @@ dependencies = [
 name = "gandiva_rust_udf_macro"
 version = "0.1.2"
 dependencies = [
+ "default-args",
  "gandiva_rust_udf_shared",
  "gandiva_rust_udf_common",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -61,7 +62,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strfmt",
- "syn",
+ "syn 2.0.52",
  "toml",
  "walkdir",
 ]
@@ -78,46 +79,9 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
-
-[[package]]
-name = "gandiva_rust_udf_shared"
-version = "0.1.0"
-dependencies = [
- "gandiva_rust_udf_type",
- "lazy_static",
- "libc",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "strfmt",
- "syn",
- "toml",
- "walkdir",
-]
-
-[[package]]
-name = "gandiva_rust_udf_type"
-version = "0.1.0"
-
-[[package]]
-name = "hashbrown"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
-
-[[package]]
-name = "indexmap"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -137,9 +101,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "memchr"
@@ -167,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "same-file"
@@ -182,29 +146,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.111"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -228,9 +192,20 @@ checksum = "7a8348af2d9fc3258c8733b8d9d8db2e56f54b2363a4b5b81585c7875ed65e65"
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -279,9 +254,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -320,9 +295,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winnow"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a4191c47f15cc3ec71fcb4913cb83d58def65dd3787610213c649283b5ce178"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
 dependencies = [
  "memchr",
 ]

--- a/gandiva_rust_udf_common/src/lib.rs
+++ b/gandiva_rust_udf_common/src/lib.rs
@@ -14,5 +14,6 @@ pub fn map_type(arg_type: &str) -> String {
         "f32" => "float32",
         "f64" => "float64",
         _ => arg_type,
-    }.to_string()
+    }
+    .to_string()
 }

--- a/gandiva_rust_udf_macro/Cargo.toml
+++ b/gandiva_rust_udf_macro/Cargo.toml
@@ -21,3 +21,6 @@ quote = "1.0.28"
 syn = { version = "2.0.18", features = ["full"] }
 gandiva_rust_udf_common = "0.1.0"
 gandiva_rust_udf_shared = "0.1.2"
+
+[dev-dependencies]
+default-args = "1.0.0"

--- a/gandiva_rust_udf_macro/Cargo.toml
+++ b/gandiva_rust_udf_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gandiva_rust_udf_macro"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["yanhuangdata"]
 description = "A basic library for gandiva rust udf macro"

--- a/gandiva_rust_udf_macro/src/attr_parser.rs
+++ b/gandiva_rust_udf_macro/src/attr_parser.rs
@@ -1,60 +1,80 @@
-use syn::{parse_macro_input, ItemFn, LitBool, LitStr};
+use syn::parse::Parser;
+use syn::{ItemFn, LitBool, LitStr};
 
-fn _parse_udf_meta(
-    attrs: proc_macro::TokenStream,
-    name: &mut Option<String>,
-    aliases: &mut Vec<String>,
-    needs_context: &mut bool,
-    result_nullable: &mut Option<String>,
-) -> proc_macro::TokenStream {
-    let udf_attr_parser = syn::meta::parser(|meta| {
-        if meta.path.is_ident("name") {
-            let value = meta.value()?;
-            let s: LitStr = value.parse()?;
-            *name = Some(s.value());
-            Ok(())
-        } else if meta.path.is_ident("aliases") {
-            let value = meta.value()?;
-            // let nested_meta = ParseNestedMeta::parse(&value)?;
-            Ok(())
-        } else if meta.path.is_ident("needs_context") {
-            let value = meta.value()?;
-            let s: LitBool = value.parse()?;
-            *needs_context = s.value;
-            Ok(())
-        } else if meta.path.is_ident("result_nullable") {
-            let value = meta.value()?;
-            let s: LitStr = value.parse()?;
-            *result_nullable = Some(s.value());
-            // only if_null/never/internal are valid values
-            if !["if_null", "never", "internal"].contains(&s.value().as_str()) {
-                return Err(meta.error("unsupported result_nullable value"));
-            }
-            Ok(())
-        } else {
-            // return an error if the attribute is not supported with meta's path
-            Err(meta.error("unsupported udf macro attribute"))
-        }
-    });
-    parse_macro_input!(attrs with udf_attr_parser);
-    proc_macro::TokenStream::new()
-}
-
-// Extract UDF meta from the #[udf(name="my_func", aliases = ("my_func1", "my_func2"))] macro attributes, including:
+// Extract UDF meta from the #[udf(name="my_func", aliases = ["my_func1", "my_func2"])] macro attributes, including:
 // 1) name
 // 2) aliases
 // 3) needs_context, needs_context can now be automatically determined by return_type
 // return a tuple of (name, aliases, needs_context)
 pub(crate) fn extract_udf_meta(
-    attrs: proc_macro::TokenStream,
-) -> (Option<String>, Vec<String>, bool, Option<String>) {
+    input: proc_macro2::TokenStream,
+) -> Result<(Option<String>, Vec<String>, bool, Option<String>), syn::Error> {
     let mut name = None;
     let mut aliases = Vec::new();
     let mut needs_context = false;
     let mut result_nullable = None;
-    _parse_udf_meta(attrs, &mut name, &mut aliases, &mut needs_context, &mut result_nullable);
-    (name, aliases, needs_context, result_nullable)
-}
+
+    let attrs = syn::Attribute::parse_outer.parse2(input)?;
+    for attr in attrs {
+        if attr.path().is_ident("udf") {
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("name") {
+                    let value = meta.value()?;
+                    let s: LitStr = value.parse()?;
+                    name = Some(s.value());
+                    Ok(())
+                } else if meta.path.is_ident("aliases") {
+                    let value = meta.value()?;
+                    let list: syn::ExprArray = value.parse()?;
+                    for expr in list.elems {
+                        if let syn::Expr::Lit(expr_lit) = expr {
+                            if let syn::Lit::Str(lit_str) = &expr_lit.lit {
+                                aliases.push(lit_str.value());
+                            } else {
+                                return Err(syn::Error::new_spanned(
+                                    expr_lit,
+                                    "Expected string literal for function alias",
+                                ));
+                            }
+                        } else {
+                            return Err(syn::Error::new_spanned(
+                                expr,
+                                "Expected string literal for function alias",
+                            ));
+                        }
+                    }
+                    Ok(())
+                } else if meta.path.is_ident("needs_context") {
+                    let value = meta.value()?;
+                    let b: LitBool = value.parse()?;
+                    needs_context = b.value;
+                    Ok(())
+                } else if meta.path.is_ident("result_nullable") {
+                    let value = meta.value()?;
+                    let s: LitStr = value.parse()?;
+                    result_nullable = Some(s.value());
+                    // only if_null/never/internal are allowed
+                    if result_nullable.as_ref().unwrap() != "if_null"
+                        && result_nullable.as_ref().unwrap() != "never"
+                        && result_nullable.as_ref().unwrap() != "internal"
+                    {
+                        return Err(syn::Error::new_spanned(
+                            meta.path,
+                            "Unsupported value for result_nullable attribute. \
+                            Only if_null, never, internal are allowed.",
+                        ));
+                    }
+                    Ok(())
+                } else {
+                    Err(syn::Error::new_spanned(
+                        meta.path,
+                        "Unknown attribute for UDF function",
+                    ))
+                }
+            })?;
+        }
+    }
+    Ok((name, aliases, needs_context, result_nullable))
 }
 
 pub(crate) fn extract_params(input: proc_macro2::TokenStream) -> ItemFn {

--- a/gandiva_rust_udf_macro/src/attr_parser.rs
+++ b/gandiva_rust_udf_macro/src/attr_parser.rs
@@ -1,5 +1,5 @@
-use syn::parse::Parser;
-use syn::{ItemFn, LitBool, LitStr};
+use syn::parse::{Parser};
+use syn::{Attribute, ItemFn, LitBool, LitStr};
 
 // Extract UDF meta from the #[udf(name="my_func", aliases = ["my_func1", "my_func2"])] macro attributes, including:
 // 1) name
@@ -14,7 +14,10 @@ pub(crate) fn extract_udf_meta(
     let mut needs_context = false;
     let mut result_nullable = None;
 
-    let attrs = syn::Attribute::parse_outer.parse2(input)?;
+    // this is a workaround to parse the attributes
+    // https://github.com/dtolnay/syn/issues/359
+    let attr_text = format!("#[udf({})]", input.to_string());
+    let attrs = Attribute::parse_outer.parse2(attr_text.parse()?)?;
     for attr in attrs {
         if attr.path().is_ident("udf") {
             attr.parse_nested_meta(|meta| {

--- a/gandiva_rust_udf_macro/src/attr_parser.rs
+++ b/gandiva_rust_udf_macro/src/attr_parser.rs
@@ -1,21 +1,49 @@
-use syn::{ItemFn, parse_macro_input};
+use syn::meta::ParseNestedMeta;
+use syn::{parse_macro_input, ItemFn, Lit, LitBool, LitStr, Meta};
 
-// needs_context can now be automatically determined by return_type, and we may not need this function anymore
-pub(crate) fn extract_needs_context(
+fn _parse_udf_meta(
     attrs: proc_macro::TokenStream,
+    name: &mut Option<String>,
+    aliases: &mut Vec<String>,
     needs_context: &mut bool,
 ) -> proc_macro::TokenStream {
     let udf_attr_parser = syn::meta::parser(|meta| {
-        if meta.path.is_ident("needs_context") {
-            *needs_context = true;
+        if meta.path.is_ident("name") {
+            let value = meta.value()?;
+            let s: LitStr = value.parse()?;
+            *name = Some(s.value());
+            Ok(())
+        } else if meta.path.is_ident("aliases") {
+            let value = meta.value()?;
+            // let nested_meta = ParseNestedMeta::parse(&value)?;
+            Ok(())
+        } else if meta.path.is_ident("needs_context") {
+            let value = meta.value()?;
+            let s: LitBool = value.parse()?;
+            *needs_context = s.value;
             Ok(())
         } else {
+            // return an error if the attribute is not supported with meta's path
             Err(meta.error("unsupported udf macro attribute"))
         }
     });
-
     parse_macro_input!(attrs with udf_attr_parser);
     proc_macro::TokenStream::new()
+}
+
+// Extract UDF meta from the #[udf(name="my_func", aliases = ("my_func1", "my_func2"))] macro attributes, including:
+// 1) name
+// 2) aliases
+// 3) needs_context, needs_context can now be automatically determined by return_type
+// return a tuple of (name, aliases, needs_context)
+pub(crate) fn extract_udf_meta(
+    attrs: proc_macro::TokenStream,
+) -> (Option<String>, Vec<String>, bool) {
+    let mut name = None;
+    let mut aliases = Vec::new();
+    let mut needs_context = false;
+    _parse_udf_meta(attrs, &mut name, &mut aliases, &mut needs_context);
+    (name, aliases, needs_context)
 }
 
 pub(crate) fn extract_params(input: proc_macro2::TokenStream) -> ItemFn {

--- a/gandiva_rust_udf_macro/src/attr_parser.rs
+++ b/gandiva_rust_udf_macro/src/attr_parser.rs
@@ -8,10 +8,11 @@ use syn::{Attribute, ItemFn, LitBool, LitStr};
 // return a tuple of (name, aliases, needs_context)
 pub(crate) fn extract_udf_meta(
     input: proc_macro2::TokenStream,
-) -> Result<(Option<String>, Vec<String>, bool, Option<String>), syn::Error> {
+) -> Result<(Option<String>, Vec<String>, bool, bool, Option<String>), syn::Error> {
     let mut name = None;
     let mut aliases = Vec::new();
     let mut needs_context = false;
+    let mut can_return_errors = false;
     let mut result_nullable = None;
 
     // this is a workaround to parse the attributes
@@ -52,6 +53,11 @@ pub(crate) fn extract_udf_meta(
                     let b: LitBool = value.parse()?;
                     needs_context = b.value;
                     Ok(())
+                } else if meta.path.is_ident("can_return_errors") {
+                    let value = meta.value()?;
+                    let b: LitBool = value.parse()?;
+                    can_return_errors = b.value;
+                    Ok(())
                 } else if meta.path.is_ident("result_nullable") {
                     let value = meta.value()?;
                     let s: LitStr = value.parse()?;
@@ -77,7 +83,7 @@ pub(crate) fn extract_udf_meta(
             })?;
         }
     }
-    Ok((name, aliases, needs_context, result_nullable))
+    Ok((name, aliases, needs_context, can_return_errors, result_nullable))
 }
 
 pub(crate) fn extract_params(input: proc_macro2::TokenStream) -> ItemFn {

--- a/gandiva_rust_udf_macro/src/lib.rs
+++ b/gandiva_rust_udf_macro/src/lib.rs
@@ -12,9 +12,6 @@ use crate::quote_helper::{
 use quote::{format_ident, quote};
 use syn::{FnArg, ReturnType};
 use gandiva_rust_udf_common::map_type;
-use crate::quote_helper::{is_returning_string, string_function_wrapper_quote, function_wrapper_quote,
-                          register_func_meta_quote, process_arg, load_registered_udfs_quote};
-use crate::attr_parser::{extract_needs_context, extract_params};
 
 #[proc_macro_attribute]
 pub fn udf_registry(

--- a/gandiva_rust_udf_macro/src/lib.rs
+++ b/gandiva_rust_udf_macro/src/lib.rs
@@ -1,6 +1,3 @@
-mod attr_parser;
-mod quote_helper;
-mod type_mapping;
 mod udf_macro_test;
 mod quote_helper;
 mod attr_parser;
@@ -12,7 +9,6 @@ use crate::quote_helper::{
     function_wrapper_quote, is_returning_string, load_registered_udfs_quote, process_arg,
     register_func_meta_quote, string_function_wrapper_quote,
 };
-use crate::type_mapping::map_type;
 use quote::{format_ident, quote};
 use syn::{FnArg, ReturnType};
 use gandiva_rust_udf_common::map_type;

--- a/gandiva_rust_udf_macro/src/lib.rs
+++ b/gandiva_rust_udf_macro/src/lib.rs
@@ -7,7 +7,7 @@ mod attr_parser;
 
 extern crate proc_macro;
 
-use crate::attr_parser::{extract_params, extract_udf_meta};
+use crate::attr_parser::{extract_params, extract_udf_meta, extract_udf_meta_impl};
 use crate::quote_helper::{
     function_wrapper_quote, is_returning_string, load_registered_udfs_quote, process_arg,
     register_func_meta_quote, string_function_wrapper_quote,
@@ -34,6 +34,7 @@ fn udf_impl(
     name: Option<String>,
     aliases: Vec<String>,
     needs_context: bool,
+    result_nullable: Option<String>,
 ) -> proc_macro2::TokenStream {
     let function = extract_params(input);
     let function_name = &function.sig.ident;
@@ -97,6 +98,7 @@ fn udf_impl(
                 name,
                 aliases,
                 final_needs_context,
+                result_nullable,
                 &return_arrow_type,
             );
             quote! {
@@ -113,10 +115,9 @@ pub fn udf(
     attrs: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    let mut needs_context = false;
-    let (name, aliases, needs_context_attr) = extract_udf_meta(attrs);
+    let (name, aliases, needs_context, result_nullable) = extract_udf_meta(attrs);
     let input = proc_macro2::TokenStream::from(input);
-    udf_impl(input, name, aliases, needs_context).into()
+    udf_impl(input, name, aliases, needs_context, result_nullable).into()
 }
 
 fn udf_registry_impl(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {

--- a/gandiva_rust_udf_macro/src/lib.rs
+++ b/gandiva_rust_udf_macro/src/lib.rs
@@ -1,9 +1,18 @@
+mod attr_parser;
+mod quote_helper;
+mod type_mapping;
 mod udf_macro_test;
 mod quote_helper;
 mod attr_parser;
 
 extern crate proc_macro;
 
+use crate::attr_parser::{extract_params, extract_udf_meta};
+use crate::quote_helper::{
+    function_wrapper_quote, is_returning_string, load_registered_udfs_quote, process_arg,
+    register_func_meta_quote, string_function_wrapper_quote,
+};
+use crate::type_mapping::map_type;
 use quote::{format_ident, quote};
 use syn::{FnArg, ReturnType};
 use gandiva_rust_udf_common::map_type;
@@ -20,18 +29,12 @@ pub fn udf_registry(
     udf_registry_impl(input).into()
 }
 
-#[proc_macro_attribute]
-pub fn udf(
-    attrs: proc_macro::TokenStream,
-    input: proc_macro::TokenStream,
-) -> proc_macro::TokenStream {
-    let mut needs_context = false;
-    let _ = extract_needs_context(attrs, &mut needs_context);
-    let input = proc_macro2::TokenStream::from(input);
-    udf_impl(input, needs_context).into()
-}
-
-fn udf_impl(input: proc_macro2::TokenStream, mut needs_context: bool) -> proc_macro2::TokenStream {
+fn udf_impl(
+    input: proc_macro2::TokenStream,
+    name: Option<String>,
+    aliases: Vec<String>,
+    needs_context: bool,
+) -> proc_macro2::TokenStream {
     let function = extract_params(input);
     let function_name = &function.sig.ident;
     let return_type = &function.sig.output;
@@ -40,9 +43,9 @@ fn udf_impl(input: proc_macro2::TokenStream, mut needs_context: bool) -> proc_ma
     let mut call_args = Vec::new();
     let mut arg_types = Vec::new();
     let is_returning_string = is_returning_string(return_type);
-    needs_context = needs_context || is_returning_string;
+    let final_needs_context = needs_context || is_returning_string;
 
-    if needs_context {
+    if final_needs_context {
         wrapper_args.push(quote! { ctx: i64 });
     }
 
@@ -70,20 +73,50 @@ fn udf_impl(input: proc_macro2::TokenStream, mut needs_context: bool) -> proc_ma
             let wrapper_func = if return_type_str == "String" {
                 return_arrow_type = "utf8".to_string();
                 wrapper_args.push(quote! { out_len: *mut i32 });
-                string_function_wrapper_quote(&function, &wrapper_name, &mut wrapper_args, &function_name, &mut call_args)
+                string_function_wrapper_quote(
+                    &function,
+                    &wrapper_name,
+                    &mut wrapper_args,
+                    &function_name,
+                    &mut call_args,
+                )
             } else {
-                function_wrapper_quote(&function, &wrapper_name, &mut wrapper_args, &function_name, &mut call_args, ty)
+                function_wrapper_quote(
+                    &function,
+                    &wrapper_name,
+                    &mut wrapper_args,
+                    &function_name,
+                    &mut call_args,
+                    ty,
+                )
             };
-            let register_func_meta = register_func_meta_quote(&function_name, &arg_types,
-                                                              &wrapper_name, needs_context, &return_arrow_type);
+            let register_func_meta = register_func_meta_quote(
+                &function_name,
+                &arg_types,
+                &wrapper_name,
+                name,
+                aliases,
+                final_needs_context,
+                &return_arrow_type,
+            );
             quote! {
                 #wrapper_func
                 #register_func_meta
             }
         }
     };
-
     expanded
+}
+
+#[proc_macro_attribute]
+pub fn udf(
+    attrs: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let mut needs_context = false;
+    let (name, aliases, needs_context_attr) = extract_udf_meta(attrs);
+    let input = proc_macro2::TokenStream::from(input);
+    udf_impl(input, name, aliases, needs_context).into()
 }
 
 fn udf_registry_impl(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {

--- a/gandiva_rust_udf_macro/src/lib.rs
+++ b/gandiva_rust_udf_macro/src/lib.rs
@@ -27,6 +27,7 @@ fn udf_impl(
     name: Option<String>,
     aliases: Vec<String>,
     needs_context: bool,
+    can_return_errors: bool,
     result_nullable: Option<String>,
 ) -> proc_macro2::TokenStream {
     let function = extract_params(input);
@@ -91,6 +92,7 @@ fn udf_impl(
                 name,
                 aliases,
                 final_needs_context,
+                can_return_errors,
                 result_nullable,
                 &return_arrow_type,
             );
@@ -109,9 +111,9 @@ pub fn udf(
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     match extract_udf_meta(attrs.into()) {
-        Ok((name, aliases, needs_context, result_nullable)) => {
+        Ok((name, aliases, needs_context, can_return_errors, result_nullable)) => {
             let input = proc_macro2::TokenStream::from(input);
-            udf_impl(input, name, aliases, needs_context, result_nullable).into()
+            udf_impl(input, name, aliases, needs_context, can_return_errors, result_nullable).into()
         }
         Err(e) => syn::Error::new_spanned(e.to_compile_error(), e.to_string())
             .to_compile_error()

--- a/gandiva_rust_udf_macro/src/quote_helper.rs
+++ b/gandiva_rust_udf_macro/src/quote_helper.rs
@@ -1,3 +1,4 @@
+use crate::type_mapping::map_type;
 use proc_macro2::Ident;
 use quote::{format_ident, quote};
 use syn::{PatType, ReturnType, Type};
@@ -16,15 +17,16 @@ fn _needs_context_quote(needs_context: bool) -> proc_macro2::TokenStream {
     if needs_context {
         quote! { needs_context: true, }
     } else {
-        quote! { }
+        quote! {}
     }
 }
 
-pub(crate) fn string_function_wrapper_quote(function: &syn::ItemFn,
-                                            wrapper_name: &Ident,
-                                            wrapper_args: &mut Vec<proc_macro2::TokenStream>,
-                                            function_name: &Ident,
-                                            call_args: &mut Vec<proc_macro2::TokenStream>,
+pub(crate) fn string_function_wrapper_quote(
+    function: &syn::ItemFn,
+    wrapper_name: &Ident,
+    wrapper_args: &mut Vec<proc_macro2::TokenStream>,
+    function_name: &Ident,
+    call_args: &mut Vec<proc_macro2::TokenStream>,
 ) -> proc_macro2::TokenStream {
     quote! {
         // output the original function
@@ -38,12 +40,14 @@ pub(crate) fn string_function_wrapper_quote(function: &syn::ItemFn,
     }
 }
 
-pub(crate) fn function_wrapper_quote(function: &syn::ItemFn,
-                                     wrapper_name: &Ident,
-                                     wrapper_args: &mut Vec<proc_macro2::TokenStream>,
-                                     function_name: &Ident,
-                                     call_args: &mut Vec<proc_macro2::TokenStream>,
-                                     ty: &Box<Type>) -> proc_macro2::TokenStream {
+pub(crate) fn function_wrapper_quote(
+    function: &syn::ItemFn,
+    wrapper_name: &Ident,
+    wrapper_args: &mut Vec<proc_macro2::TokenStream>,
+    function_name: &Ident,
+    call_args: &mut Vec<proc_macro2::TokenStream>,
+    ty: &Box<Type>,
+) -> proc_macro2::TokenStream {
     quote! {
       // output the original function
       #function
@@ -55,29 +59,38 @@ pub(crate) fn function_wrapper_quote(function: &syn::ItemFn,
     }
 }
 
-pub(crate) fn register_func_meta_quote(function_name: &Ident, arg_types: &Vec<String>,
-                                       wrapper_name: &Ident, needs_context: bool,
-                                       return_arrow_type: &str) -> proc_macro2::TokenStream {
+pub(crate) fn register_func_meta_quote(
+    function_name: &Ident,
+    arg_types: &Vec<String>,
+    wrapper_name: &Ident,
+    name: Option<String>,
+    aliases: Vec<String>,
+    needs_context: bool,
+    return_arrow_type: &str,
+) -> proc_macro2::TokenStream {
     let base_name_str = function_name.to_string();
-    let arg_types_quotes = arg_types.iter().map(|arg_type| { _data_type_quote(arg_type) });
+    let arg_types_quotes = arg_types.iter().map(|arg_type| _data_type_quote(arg_type));
     let pc_name_str = wrapper_name.to_string();
     // register the wrapper function metadata
     let register_func_ident = format_ident!("register_{}", wrapper_name);
     let return_type_quote = _data_type_quote(return_arrow_type);
+    let udf_name = name.unwrap_or(base_name_str.clone());
+
     // conditionally add needs_context
     let needs_context_quote = _needs_context_quote(needs_context);
     let register_func_meta = quote! {
-                pub fn #register_func_ident() {
-                    gandiva_rust_udf_shared::register_udf(gandiva_rust_udf_shared::UdfMetaData {
-                        name: #base_name_str.to_string(),
-                        param_types: vec![#(#arg_types_quotes),*],
-                        return_type: #return_type_quote,
-                        pc_name: #pc_name_str.to_string(),
-                        #needs_context_quote
-                        ..Default::default()
-                    });
-                }
-            };
+        pub fn #register_func_ident() {
+            gandiva_rust_udf_shared::register_udf(gandiva_rust_udf_shared::UdfMetaData {
+                name: #udf_name.to_string(),
+                aliases: vec![#(#aliases),*],
+                param_types: vec![#(#arg_types_quotes),*],
+                return_type: #return_type_quote,
+                pc_name: #pc_name_str.to_string(),
+                #needs_context_quote
+                ..Default::default()
+            });
+        }
+    };
     register_func_meta
 }
 
@@ -97,10 +110,12 @@ pub(crate) fn is_returning_string(return_type: &ReturnType) -> bool {
     false
 }
 
-pub(crate) fn process_arg(PatType { ty, pat, .. }: &PatType,
-                          wrapper_args: &mut Vec<proc_macro2::TokenStream>,
-                          call_args: &mut Vec<proc_macro2::TokenStream>,
-                          arg_types: &mut Vec<String>) {
+pub(crate) fn process_arg(
+    PatType { ty, pat, .. }: &PatType,
+    wrapper_args: &mut Vec<proc_macro2::TokenStream>,
+    call_args: &mut Vec<proc_macro2::TokenStream>,
+    arg_types: &mut Vec<String>,
+) {
     let arg_name = pat;
     let arg_type = quote!(#ty).to_string();
     // if arg_type is ["i8" | "i16" | "i32" | "i64"] ==> ["int_8" | "int_16" | "int_32" | "int_64"]
@@ -111,8 +126,8 @@ pub(crate) fn process_arg(PatType { ty, pat, .. }: &PatType,
         let arg_name_len = format_ident!("{}_len", quote!(#arg_name).to_string());
         wrapper_args.push(quote! { #arg_name: *const libc::c_char, #arg_name_len: i32 });
         call_args.push(quote! { std::str::from_utf8(
-                    unsafe { std::slice::from_raw_parts(#arg_name as *const u8, #arg_name_len as usize) }
-                ).unwrap() });
+            unsafe { std::slice::from_raw_parts(#arg_name as *const u8, #arg_name_len as usize) }
+        ).unwrap() });
     } else {
         wrapper_args.push(quote! { #arg_name: #ty });
         call_args.push(quote! { #arg_name });

--- a/gandiva_rust_udf_macro/src/quote_helper.rs
+++ b/gandiva_rust_udf_macro/src/quote_helper.rs
@@ -1,4 +1,3 @@
-use crate::type_mapping::map_type;
 use proc_macro2::Ident;
 use quote::{format_ident, quote};
 use syn::{PatType, ReturnType, Type};

--- a/gandiva_rust_udf_macro/src/quote_helper.rs
+++ b/gandiva_rust_udf_macro/src/quote_helper.rs
@@ -20,6 +20,14 @@ fn _needs_context_quote(needs_context: bool) -> proc_macro2::TokenStream {
     }
 }
 
+fn _can_return_errors_quote(can_return_errors: bool) -> proc_macro2::TokenStream {
+    if can_return_errors {
+        quote! { can_return_errors: true, }
+    } else {
+        quote! {}
+    }
+}
+
 fn _result_nullable_quote(result_nullable: Option<String>) -> proc_macro2::TokenStream {
     if let Some(result_nullable) = result_nullable {
         quote! { result_nullable: #result_nullable.to_string(), }
@@ -73,6 +81,7 @@ pub(crate) fn register_func_meta_quote(
     name: Option<String>,
     aliases: Vec<String>,
     needs_context: bool,
+    can_return_errors: bool,
     result_nullable: Option<String>,
     return_arrow_type: &str,
 ) -> proc_macro2::TokenStream {
@@ -89,6 +98,7 @@ pub(crate) fn register_func_meta_quote(
 
     // conditionally add needs_context
     let needs_context_quote = _needs_context_quote(needs_context);
+    let can_return_errors_quote = _can_return_errors_quote(can_return_errors);
     let register_func_meta = quote! {
         pub fn #register_func_ident() {
             gandiva_rust_udf_shared::register_udf(gandiva_rust_udf_shared::UdfMetaData {
@@ -99,6 +109,7 @@ pub(crate) fn register_func_meta_quote(
                 pc_name: #pc_name_str.to_string(),
                 #result_nullable_quote
                 #needs_context_quote
+                #can_return_errors_quote
                 ..Default::default()
             });
         }

--- a/gandiva_rust_udf_macro/src/udf_macro_test.rs
+++ b/gandiva_rust_udf_macro/src/udf_macro_test.rs
@@ -1,7 +1,19 @@
 #[cfg(test)]
-mod tests {
+mod macro_tests {
     use crate::udf_impl;
     use crate::udf_registry_impl;
+    use default_args::default_args;
+
+    default_args! {
+        fn gen_udf(
+            input: proc_macro2::TokenStream,
+            name: Option<String> = None,
+            aliases: Vec<String> = Vec::new(),
+            needs_context: bool = false
+        ) -> proc_macro2::TokenStream {
+            udf_impl(input, name, aliases, needs_context)
+        }
+    }
 
     #[test]
     fn test_no_arg_udf() {
@@ -22,6 +34,7 @@ mod tests {
             pub fn register_my_udf_() {
                 gandiva_rust_udf_shared::register_udf(gandiva_rust_udf_shared::UdfMetaData {
                     name: "my_udf".to_string(),
+                    aliases: vec![],
                     param_types: vec![],
                     return_type: gandiva_rust_udf_shared::DataType { type_name: "float64".to_string(), ..Default::default() },
                     pc_name: "my_udf_".to_string(),
@@ -29,7 +42,7 @@ mod tests {
                 });
             }
         };
-        let actual = udf_impl(input, false);
+        let actual = gen_udf!(input);
         assert_eq!(actual.to_string(), expected.to_string());
     }
 
@@ -52,6 +65,7 @@ mod tests {
             pub fn register_my_udf_int64() {
                 gandiva_rust_udf_shared::register_udf(gandiva_rust_udf_shared::UdfMetaData {
                     name: "my_udf".to_string(),
+                    aliases: vec![],
                     param_types: vec![gandiva_rust_udf_shared::DataType { type_name: "int64".to_string(), ..Default::default() }],
                     return_type: gandiva_rust_udf_shared::DataType { type_name: "float64".to_string(), ..Default::default() },
                     pc_name: "my_udf_int64".to_string(),
@@ -59,7 +73,7 @@ mod tests {
                 });
             }
         };
-        let actual = udf_impl(input, false);
+        let actual = gen_udf!(input);
         assert_eq!(actual.to_string(), expected.to_string());
     }
 
@@ -82,6 +96,7 @@ mod tests {
             pub fn register_my_udf_boolean() {
                 gandiva_rust_udf_shared::register_udf(gandiva_rust_udf_shared::UdfMetaData {
                     name: "my_udf".to_string(),
+                    aliases: vec![],
                     param_types: vec![gandiva_rust_udf_shared::DataType { type_name: "boolean".to_string(), ..Default::default() }],
                     return_type: gandiva_rust_udf_shared::DataType { type_name: "boolean".to_string(), ..Default::default() },
                     pc_name: "my_udf_boolean".to_string(),
@@ -89,7 +104,7 @@ mod tests {
                 });
             }
         };
-        let actual = udf_impl(input, false);
+        let actual = gen_udf!(input);
         assert_eq!(actual.to_string(), expected.to_string());
     }
 
@@ -112,6 +127,7 @@ mod tests {
             pub fn register_my_udf_int64_int32() {
                 gandiva_rust_udf_shared::register_udf(gandiva_rust_udf_shared::UdfMetaData {
                     name: "my_udf".to_string(),
+                    aliases: vec![],
                     param_types: vec![
                         gandiva_rust_udf_shared::DataType { type_name: "int64".to_string(), ..Default::default() },
                         gandiva_rust_udf_shared::DataType { type_name: "int32".to_string(), ..Default::default() }
@@ -122,7 +138,7 @@ mod tests {
                 });
             }
         };
-        let actual = udf_impl(input, false);
+        let actual = gen_udf!(input);
         assert_eq!(actual.to_string(), expected.to_string());
     }
 
@@ -147,6 +163,7 @@ mod tests {
             pub fn register_my_udf_utf8() {
                 gandiva_rust_udf_shared::register_udf(gandiva_rust_udf_shared::UdfMetaData {
                     name: "my_udf".to_string(),
+                    aliases: vec![],
                     param_types: vec![gandiva_rust_udf_shared::DataType { type_name: "utf8".to_string(), ..Default::default() }],
                     return_type: gandiva_rust_udf_shared::DataType { type_name: "boolean".to_string(), ..Default::default() },
                     pc_name: "my_udf_utf8".to_string(),
@@ -154,7 +171,7 @@ mod tests {
                 });
             }
         };
-        let actual = udf_impl(input, false);
+        let actual = gen_udf!(input);
         assert_eq!(actual.to_string(), expected.to_string());
     }
 
@@ -179,6 +196,7 @@ mod tests {
             pub fn register_my_udf_utf8() {
                 gandiva_rust_udf_shared::register_udf(gandiva_rust_udf_shared::UdfMetaData {
                     name: "my_udf".to_string(),
+                    aliases: vec![],
                     param_types: vec![gandiva_rust_udf_shared::DataType { type_name: "utf8".to_string(), ..Default::default() }],
                     return_type: gandiva_rust_udf_shared::DataType { type_name: "boolean".to_string(), ..Default::default() },
                     pc_name: "my_udf_utf8".to_string(),
@@ -187,7 +205,7 @@ mod tests {
                 });
             }
         };
-        let actual = udf_impl(input, true);
+        let actual = gen_udf!(input);
         assert_eq!(actual.to_string(), expected.to_string());
     }
 
@@ -211,6 +229,7 @@ mod tests {
             pub fn register_my_udf_int64() {
                 gandiva_rust_udf_shared::register_udf(gandiva_rust_udf_shared::UdfMetaData {
                     name: "my_udf".to_string(),
+                    aliases: vec![],
                     param_types: vec![gandiva_rust_udf_shared::DataType { type_name: "int64".to_string(), ..Default::default() }],
                     return_type: gandiva_rust_udf_shared::DataType { type_name: "utf8".to_string(), ..Default::default() },
                     pc_name: "my_udf_int64".to_string(),
@@ -219,7 +238,7 @@ mod tests {
                 });
             }
         };
-        let actual = udf_impl(input, true);
+        let actual = gen_udf!(input);
         assert_eq!(actual.to_string(), expected.to_string());
     }
 

--- a/gandiva_rust_udf_macro/src/udf_macro_test.rs
+++ b/gandiva_rust_udf_macro/src/udf_macro_test.rs
@@ -367,12 +367,10 @@ mod macro_tests {
     #[test]
     fn test_extract_udf_meta() {
         let input: proc_macro2::TokenStream = quote::quote! {
-            #[udf(
-                name = "my_udf",
-                aliases = ["your_udf"],
-                needs_context = true,
-                result_nullable = "never"
-            )]
+            name = "my_udf",
+            aliases = ["your_udf"],
+            needs_context = true,
+            result_nullable = "never"
         };
         let expected = (
             Some("my_udf".to_string()),
@@ -387,7 +385,7 @@ mod macro_tests {
     #[test]
     fn test_extract_invalid_alias() {
         let input: proc_macro2::TokenStream = quote::quote! {
-            #[udf(aliases = [42])]
+            aliases = [42]
         };
         let actual = extract_udf_meta(input);
         // assert error occurs
@@ -400,7 +398,7 @@ mod macro_tests {
     #[test]
     fn test_extract_invalid_attribute() {
         let input: proc_macro2::TokenStream = quote::quote! {
-            #[udf(no_such_attr = 42)]
+            no_such_attr = 42
         };
         let actual = extract_udf_meta(input);
         assert_eq!(
@@ -412,7 +410,7 @@ mod macro_tests {
     #[test]
     fn test_extract_name_should_be_string() {
         let input: proc_macro2::TokenStream = quote::quote! {
-            #[udf(name = 42)]
+            name = 42
         };
         let actual = extract_udf_meta(input);
         assert_eq!(actual.err().unwrap().to_string(), "expected string literal");
@@ -421,7 +419,7 @@ mod macro_tests {
     #[test]
     fn test_extract_alias_should_be_array() {
         let input: proc_macro2::TokenStream = quote::quote! {
-            #[udf(aliases = "your_udf")]
+            aliases = "your_udf"
         };
         let actual = extract_udf_meta(input);
         assert_eq!(
@@ -433,7 +431,7 @@ mod macro_tests {
     #[test]
     fn test_extract_result_nullable_should_be_string() {
         let input: proc_macro2::TokenStream = quote::quote! {
-            #[udf(result_nullable = "if_null")]
+            result_nullable = "if_null"
         };
         let expected = (None, vec![], false, Some("if_null".to_string()));
         let actual = extract_udf_meta(input);
@@ -443,7 +441,7 @@ mod macro_tests {
     #[test]
     fn test_extract_invalid_result_nullable_value() {
         let input: proc_macro2::TokenStream = quote::quote! {
-            #[udf(result_nullable = "no_supported_nullable_value")]
+            result_nullable = "no_supported_nullable_value"
         };
         let actual = extract_udf_meta(input);
         assert_eq!(
@@ -455,7 +453,7 @@ mod macro_tests {
     #[test]
     fn test_extract_needs_context_should_be_bool() {
         let input: proc_macro2::TokenStream = quote::quote! {
-            #[udf(needs_context = 42)]
+            needs_context = 42
         };
         let actual = extract_udf_meta(input);
         assert_eq!(
@@ -467,12 +465,10 @@ mod macro_tests {
     #[test]
     fn test_extract_udf_meta_multi_aliases_false_needs_context() {
         let input: proc_macro2::TokenStream = quote::quote! {
-            #[udf(
-                name = "my_udf",
-                aliases = ["your_udf", "her_udf"],
-                needs_context = false,
-                result_nullable = "internal"
-            )]
+            name = "my_udf",
+            aliases = ["your_udf", "her_udf"],
+            needs_context = false,
+            result_nullable = "internal"
         };
         let expected = (
             Some("my_udf".to_string()),

--- a/gandiva_rust_udf_macro/src/udf_macro_test.rs
+++ b/gandiva_rust_udf_macro/src/udf_macro_test.rs
@@ -11,9 +11,10 @@ mod macro_tests {
             name: Option<String> = None,
             aliases: Vec<String> = Vec::new(),
             needs_context: bool = false,
+            can_return_errors: bool = false,
             result_nullable: Option<String> = None,
         ) -> proc_macro2::TokenStream {
-            udf_impl(input, name, aliases, needs_context, result_nullable)
+            udf_impl(input, name, aliases, needs_context, can_return_errors, result_nullable)
         }
     }
 
@@ -376,6 +377,7 @@ mod macro_tests {
             Some("my_udf".to_string()),
             vec!["your_udf".to_string()],
             true,
+            false,
             Some("never".to_string()),
         );
         let actual = extract_udf_meta(input);
@@ -433,7 +435,7 @@ mod macro_tests {
         let input: proc_macro2::TokenStream = quote::quote! {
             result_nullable = "if_null"
         };
-        let expected = (None, vec![], false, Some("if_null".to_string()));
+        let expected = (None, vec![], false, false, Some("if_null".to_string()));
         let actual = extract_udf_meta(input);
         assert_eq!(actual.unwrap(), expected);
     }
@@ -474,7 +476,38 @@ mod macro_tests {
             Some("my_udf".to_string()),
             vec!["your_udf".to_string(), "her_udf".to_string()],
             false,
+            false,
             Some("internal".to_string()),
+        );
+        let actual = extract_udf_meta(input);
+        assert_eq!(actual.unwrap(), expected);
+    }
+
+    #[test]
+    fn test_extract_udf_meta_default() {
+        let input: proc_macro2::TokenStream = quote::quote! {};
+        let expected = (
+            None,
+            vec![],
+            false,
+            false,
+            None,
+        );
+        let actual = extract_udf_meta(input);
+        assert_eq!(actual.unwrap(), expected);
+    }
+
+    #[test]
+    fn test_extract_udf_meta_can_return_errors() {
+        let input: proc_macro2::TokenStream = quote::quote! {
+            can_return_errors = true
+        };
+        let expected = (
+            None,
+            vec![],
+            false,
+            true,
+            None,
         );
         let actual = extract_udf_meta(input);
         assert_eq!(actual.unwrap(), expected);


### PR DESCRIPTION
Support specifying function name and aliases in `udf` macro. For example:
```
#udf[name = "format", aliases = ["my_format"]]
fn format_impl(...)
```